### PR TITLE
Add Streamlit options practice app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,34 @@
-﻿# optionsMock
+# optionsMock
 
-A Streamlit application for Windows.
+An interactive Streamlit app for practicing options trading concepts. The app includes:
+
+- **Put-Call Parity Practice** with randomly generated parameters
+- **Delta Hedging Simulation** using a simple random walk
+- **Quiz Mode** to test knowledge of options theory
 
 ## Getting Started
 
 1. Install dependencies:
-    `ash
-    pip install -r requirements.txt
-    `
-
+   ```bash
+   pip install -r requirements.txt
+   ```
 2. Run the app:
-    `ash
-    streamlit run app.py
-    `
+   ```bash
+   streamlit run app.py
+   ```
 
 ## Requirements
 
 - Python 3.8+
-- Streamlit
+- Streamlit, NumPy, SciPy, Matplotlib, pandas
 
 ## Project Structure
 
-- pp.py – Main Streamlit application file
-- equirements.txt – Python dependencies
-
-## Notes
+- `app.py` – Streamlit application entry point
+- `option_pricing.py` – Black-Scholes utilities and Greek calculations
+- `parity.py` – Functions for put-call parity practice
+- `delta_hedging.py` – Helpers for delta hedging simulation
+- `quiz.py` – Quiz logic
+Quiz results are stored in `quiz_history.csv`.
 
 This project is intended for use on Windows systems.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,97 @@
+import streamlit as st
+import numpy as np
+
+from option_pricing import call_price
+import parity
+import delta_hedging as dh
+import quiz
+
+
+st.title("Options Practice App")
+
+page = st.sidebar.radio(
+    "Select Mode",
+    ("Put-Call Parity", "Delta Hedging", "Quiz"),
+)
+
+if page == "Put-Call Parity":
+    st.header("Put-Call Parity Practice")
+    if st.button("Generate New Parameters") or "pcp_params" not in st.session_state:
+        st.session_state.pcp_params = parity.generate_parameters()
+    params = st.session_state.pcp_params
+
+    st.write(
+        f"Spot (S) = {params['S']:.2f}, Strike (K) = {params['K']:.2f}, Call Price (C) = {params['C']:.2f}, "
+        f"Put Price (P) = {params['P']:.2f}, r = {params['r']:.3f}, T = {params['T']:.2f}"
+    )
+
+    violation_user = st.radio("Is parity violated?", ("Yes", "No"))
+    trade_user = st.radio(
+        "Arbitrage Trade",
+        (
+            "Buy call, sell put, buy stock, borrow PV(K)",
+            "Sell call, buy put, short stock, lend PV(K)",
+            "No trade",
+        ),
+    )
+
+    if st.button("Check Answer"):
+        violated, diff = parity.parity_violation(params)
+        arb = parity.arbitrage_strategy(diff)
+        correct = (
+            (violated and violation_user == "Yes")
+            or (not violated and violation_user == "No")
+        ) and trade_user == arb
+        st.write("Correct" if correct else "Incorrect")
+        st.latex(r"C - P = S - K e^{-r T}")
+        st.write(f"Difference: {diff:.2f}")
+        fig = parity.payoff_diagram(params, diff)
+        st.pyplot(fig)
+
+elif page == "Delta Hedging":
+    st.header("Delta Hedging Simulation")
+    S0 = 100.0
+    K = 100.0
+    r = 0.01
+    T = 1.0
+    dt = 1 / 52
+
+    if "dh_state" not in st.session_state:
+        st.session_state.dh_state = dh.init_state(S0, K, r, T)
+
+    hedge_ratio = st.slider("Hedge Ratio (shares)", -2.0, 2.0, 0.0, step=0.1)
+    col1, col2 = st.columns(2)
+    if col1.button("Next Step"):
+        st.session_state.dh_state = dh.update_state(
+            st.session_state.dh_state, hedge_ratio, K, r, T, dt
+        )
+    if col2.button("Reset"):
+        st.session_state.dh_state = dh.init_state(S0, K, r, T)
+
+    st.write(st.session_state.dh_state)
+    st.line_chart(
+        {
+            "Stock": [st.session_state.dh_state["S"]],
+            "Delta": [st.session_state.dh_state["delta"]],
+        }
+    )
+
+elif page == "Quiz":
+    st.header("Quiz")
+    if "quiz" not in st.session_state:
+        q, opts, ans, idx = quiz.ask_question()
+        st.session_state.quiz = {"q": q, "opts": opts, "ans": ans, "idx": idx}
+
+    qdata = st.session_state.quiz
+    st.write(qdata["q"])
+    choice = st.radio("Answer", qdata["opts"])
+    if st.button("Submit Answer"):
+        correct = qdata["opts"].index(choice) == qdata["ans"]
+        quiz.record_result(correct)
+        st.write("Correct" if correct else "Incorrect")
+        # load new question
+        q, opts, ans, idx = quiz.ask_question()
+        st.session_state.quiz = {"q": q, "opts": opts, "ans": ans, "idx": idx}
+
+    score, total = quiz.load_history()
+    st.write(f"Score: {score}/{total}")

--- a/delta_hedging.py
+++ b/delta_hedging.py
@@ -1,0 +1,46 @@
+import numpy as np
+from option_pricing import call_price, call_delta
+
+
+ndefault_sigma = 0.2
+
+def simulate_step(S_prev, r, sigma, dt):
+    """Simulate next stock price using geometric Brownian motion"""
+    dW = np.random.normal(scale=np.sqrt(dt))
+    return S_prev * np.exp((r - 0.5 * sigma ** 2) * dt + sigma * dW)
+
+
+def init_state(S0, K, r, T, sigma=ndefault_sigma):
+    price = call_price(S0, K, r, T, sigma)
+    delta = call_delta(S0, K, r, T, sigma)
+    return {
+        "S": S0,
+        "t": 0.0,
+        "cash": price,  # premium received from selling the call
+        "delta": delta,
+        "option_price": price,
+    }
+
+
+def update_state(state, hedge_ratio, K, r, T, dt, sigma=ndefault_sigma):
+    S_new = simulate_step(state["S"], r, sigma, dt)
+    t_new = state["t"] + dt
+    option_new = call_price(S_new, K, r, T - t_new, sigma)
+    delta_new = call_delta(S_new, K, r, T - t_new, sigma)
+
+    # Hedge P&L from holding shares
+    hedge_pnl = hedge_ratio * (S_new - state["S"])
+
+    # Option P&L (short position)
+    option_pnl = -(option_new - state["option_price"])
+
+    cash_new = state["cash"] + hedge_pnl + option_pnl
+
+    state.update({
+        "S": S_new,
+        "t": t_new,
+        "cash": cash_new,
+        "option_price": option_new,
+        "delta": delta_new,
+    })
+    return state

--- a/option_pricing.py
+++ b/option_pricing.py
@@ -1,0 +1,32 @@
+import numpy as np
+from scipy.stats import norm
+
+
+def d1(S, K, r, T, sigma):
+    return (np.log(S / K) + (r + 0.5 * sigma ** 2) * T) / (sigma * np.sqrt(T))
+
+
+def d2(S, K, r, T, sigma):
+    return d1(S, K, r, T, sigma) - sigma * np.sqrt(T)
+
+
+def call_price(S, K, r, T, sigma):
+    """Black-Scholes call price"""
+    D1 = d1(S, K, r, T, sigma)
+    D2 = d2(S, K, r, T, sigma)
+    return S * norm.cdf(D1) - K * np.exp(-r * T) * norm.cdf(D2)
+
+
+def put_price(S, K, r, T, sigma):
+    """Black-Scholes put price"""
+    D1 = d1(S, K, r, T, sigma)
+    D2 = d2(S, K, r, T, sigma)
+    return K * np.exp(-r * T) * norm.cdf(-D2) - S * norm.cdf(-D1)
+
+
+def call_delta(S, K, r, T, sigma):
+    return norm.cdf(d1(S, K, r, T, sigma))
+
+
+def put_delta(S, K, r, T, sigma):
+    return call_delta(S, K, r, T, sigma) - 1

--- a/parity.py
+++ b/parity.py
@@ -1,0 +1,64 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from option_pricing import call_price, put_price
+
+
+def generate_parameters():
+    S = np.random.uniform(80, 120)
+    K = np.random.uniform(80, 120)
+    r = np.random.uniform(0.0, 0.05)
+    T = np.random.uniform(0.25, 1.0)  # in years
+    sigma = 0.2
+
+    C = call_price(S, K, r, T, sigma)
+    P = put_price(S, K, r, T, sigma)
+
+    # Introduce small random noise to potentially create parity violation
+    noise = np.random.normal(scale=0.5)
+    if np.random.rand() > 0.5:
+        C += noise
+    else:
+        P += noise
+
+    params = {"S": S, "K": K, "C": C, "P": P, "r": r, "T": T}
+    return params
+
+
+def parity_violation(params, tol=1e-2):
+    lhs = params["C"] - params["P"]
+    rhs = params["S"] - params["K"] * np.exp(-params["r"] * params["T"])
+    diff = lhs - rhs
+    return abs(diff) > tol, diff
+
+
+def arbitrage_strategy(diff):
+    if diff > 0:
+        return "Sell call, buy put, short stock, lend PV(K)"
+    elif diff < 0:
+        return "Buy call, sell put, buy stock, borrow PV(K)"
+    else:
+        return "No arbitrage"
+
+
+def payoff_diagram(params, diff):
+    S_vals = np.linspace(0.5 * params["K"], 1.5 * params["K"], 100)
+    if diff > 0:
+        payoff = (
+            -call_price(S_vals, params["K"], params["r"], params["T"], 0.2)
+            + put_price(S_vals, params["K"], params["r"], params["T"], 0.2)
+            - S_vals
+            + params["K"] * np.exp(-params["r"] * params["T"])
+        )
+    else:
+        payoff = (
+            call_price(S_vals, params["K"], params["r"], params["T"], 0.2)
+            - put_price(S_vals, params["K"], params["r"], params["T"], 0.2)
+            + S_vals
+            - params["K"] * np.exp(-params["r"] * params["T"])
+        )
+    fig, ax = plt.subplots()
+    ax.plot(S_vals, payoff)
+    ax.axhline(0, color="k", linestyle="--")
+    ax.set_xlabel("Stock Price at Expiration")
+    ax.set_ylabel("Arbitrage Payoff")
+    return fig

--- a/quiz.py
+++ b/quiz.py
@@ -1,0 +1,54 @@
+import random
+import pandas as pd
+from pathlib import Path
+
+
+QUESTIONS = [
+    {
+        "question": "Which Greek measures sensitivity of option price to underlying price?",
+        "options": ["Delta", "Gamma", "Theta", "Vega"],
+        "answer": 0,
+    },
+    {
+        "question": "If put-call parity is violated with C - P > S - Ke^{-rT}, what trade exploits it?",
+        "options": [
+            "Buy call, sell put, buy stock, borrow PV(K)",
+            "Sell call, buy put, short stock, lend PV(K)",
+            "Buy call and put", "Do nothing",
+        ],
+        "answer": 1,
+    },
+    {
+        "question": "Delta of a call option is typically between?",
+        "options": ["0 and 1", "-1 and 0", "1 and 2", "-2 and -1"],
+        "answer": 0,
+    },
+]
+
+HISTORY_FILE = Path("quiz_history.csv")
+
+
+def ask_question(idx=None):
+    if idx is None:
+        idx = random.randrange(len(QUESTIONS))
+    q = QUESTIONS[idx]
+    return q["question"], q["options"], q["answer"], idx
+
+
+def record_result(correct):
+    df = pd.DataFrame([{"correct": int(correct)}])
+    if HISTORY_FILE.exists():
+        df_all = pd.read_csv(HISTORY_FILE)
+        df_all = pd.concat([df_all, df], ignore_index=True)
+    else:
+        df_all = df
+    df_all.to_csv(HISTORY_FILE, index=False)
+
+
+def load_history():
+    if HISTORY_FILE.exists():
+        df = pd.read_csv(HISTORY_FILE)
+        score = df["correct"].sum()
+        total = len(df)
+        return score, total
+    return 0, 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
-﻿streamlit
+streamlit
+numpy
+scipy
+matplotlib
+pandas


### PR DESCRIPTION
## Summary
- build a basic Streamlit app for options trading practice
- add modules for option pricing, put-call parity, delta hedging, and quiz logic
- store quiz results locally
- update README and dependencies

## Testing
- `python -m py_compile app.py option_pricing.py delta_hedging.py parity.py quiz.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d363a91648333802f9e3a96b8141b