### PR TITLE
Improve parity page UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,10 +20,18 @@ if page == "Put-Call Parity":
         st.session_state.pcp_params = parity.generate_parameters()
     params = st.session_state.pcp_params
 
-    st.write(
-        f"Spot (S) = {params['S']:.2f}, Strike (K) = {params['K']:.2f}, Call Price (C) = {params['C']:.2f}, "
-        f"Put Price (P) = {params['P']:.2f}, r = {params['r']:.3f}, T = {params['T']:.2f}"
+    param_eq = (
+        rf"S = {params['S']:.2f},\; K = {params['K']:.2f},\; C = {params['C']:.2f},\;"
+        rf"\; P = {params['P']:.2f},\; r = {params['r']:.3f},\; T = {params['T']:.2f}"
     )
+    st.latex(param_eq)
+
+    if 'show_formula' not in st.session_state:
+        st.session_state.show_formula = False
+    if st.button("Show Parity Formula"):
+        st.session_state.show_formula = True
+    if st.session_state.show_formula:
+        st.latex(r"C - P = S - K e^{-r T}")
 
     violation_user = st.radio("Is parity violated?", ("Yes", "No"))
     trade_user = st.radio(


### PR DESCRIPTION
## Summary
- format put-call parity parameters with LaTeX
- add button to show parity formula

## Testing
- `python -m py_compile app.py option_pricing.py parity.py delta_hedging.py quiz.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d401708688333bc89990d9d93774f