### PR TITLE
Add options chain simulator

### DIFF
--- a/option_pricing.py
+++ b/option_pricing.py
@@ -30,3 +30,45 @@ def call_delta(S, K, r, T, sigma):
 
 def put_delta(S, K, r, T, sigma):
     return call_delta(S, K, r, T, sigma) - 1
+
+
+def gamma(S, K, r, T, sigma):
+    """Black-Scholes gamma (same for calls and puts)"""
+    D1 = d1(S, K, r, T, sigma)
+    return norm.pdf(D1) / (S * sigma * np.sqrt(T))
+
+
+def vega(S, K, r, T, sigma):
+    """Black-Scholes vega (same for calls and puts)"""
+    D1 = d1(S, K, r, T, sigma)
+    return S * norm.pdf(D1) * np.sqrt(T)
+
+
+def call_theta(S, K, r, T, sigma):
+    """Black-Scholes theta for a call"""
+    D1 = d1(S, K, r, T, sigma)
+    D2 = d2(S, K, r, T, sigma)
+    term1 = -(S * norm.pdf(D1) * sigma) / (2 * np.sqrt(T))
+    term2 = r * K * np.exp(-r * T) * norm.cdf(D2)
+    return term1 - term2
+
+
+def put_theta(S, K, r, T, sigma):
+    """Black-Scholes theta for a put"""
+    D1 = d1(S, K, r, T, sigma)
+    D2 = d2(S, K, r, T, sigma)
+    term1 = -(S * norm.pdf(D1) * sigma) / (2 * np.sqrt(T))
+    term2 = r * K * np.exp(-r * T) * norm.cdf(-D2)
+    return term1 + term2
+
+
+def call_rho(S, K, r, T, sigma):
+    """Black-Scholes rho for a call"""
+    D2 = d2(S, K, r, T, sigma)
+    return K * T * np.exp(-r * T) * norm.cdf(D2)
+
+
+def put_rho(S, K, r, T, sigma):
+    """Black-Scholes rho for a put"""
+    D2 = d2(S, K, r, T, sigma)
+    return -K * T * np.exp(-r * T) * norm.cdf(-D2)

--- a/options_chain.py
+++ b/options_chain.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pandas as pd
+
+from option_pricing import (
+    call_price,
+    put_price,
+    call_delta,
+    put_delta,
+    gamma,
+    vega,
+    call_rho,
+    put_rho,
+)
+
+
+def generate_chain(S, r, expiries, strikes, sigma):
+    """Return DataFrame of option metrics for given parameters."""
+    rows = []
+    for T in expiries:
+        for K in strikes:
+            c_price = call_price(S, K, r, T, sigma)
+            p_price = put_price(S, K, r, T, sigma)
+            c_delta = call_delta(S, K, r, T, sigma)
+            p_delta = put_delta(S, K, r, T, sigma)
+            g = gamma(S, K, r, T, sigma)
+            v = vega(S, K, r, T, sigma)
+            c_rho = call_rho(S, K, r, T, sigma)
+            p_rho = put_rho(S, K, r, T, sigma)
+            revcon = c_price - p_price - S + K * np.exp(-r * T)
+            rows.append({
+                "Expiry": T,
+                "Strike": K,
+                "Call Delta": c_delta,
+                "Call Price": c_price,
+                "Put Price": p_price,
+                "Put Delta": p_delta,
+                "IV": sigma,
+                "Vega": v,
+                "Gamma": g,
+                "RevCon": revcon,
+                "cRho": c_rho,
+                "pRho": p_rho,
+            })
+    return pd.DataFrame(rows)
+


### PR DESCRIPTION
## Summary
- add Black-Scholes Greeks (gamma, vega, theta, rho)
- create generator for an options chain table
- integrate new options chain page into the Streamlit app

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d41b32c5083339f22a91b91c73493