### PR TITLE
Add arbitrage simulator panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,13 +6,14 @@ from options_chain import generate_chain
 import parity
 import delta_hedging as dh
 import quiz
+import trade_simulation as ts
 
 
 st.title("Options Practice App")
 
 page = st.sidebar.radio(
     "Select Mode",
-    ("Options Chain", "Put-Call Parity", "Delta Hedging", "Quiz"),
+    ("Options Chain", "Put-Call Parity", "Arbitrage Simulator", "Delta Hedging", "Quiz"),
 )
 
 if page == "Options Chain":
@@ -84,7 +85,43 @@ elif page == "Put-Call Parity":
         st.latex(r"C - P = S - K e^{-r T}")
         st.write(f"Difference: {diff:.2f}")
         fig = parity.payoff_diagram(params, diff)
-        st.pyplot(fig)
+
+elif page == "Arbitrage Simulator":
+    st.header("Mock Trade Simulation")
+    if st.button("Generate Scenario") or "sim_params" not in st.session_state:
+        st.session_state.sim_params = parity.generate_parameters()
+    params = st.session_state.sim_params
+
+    eq = (
+        rf"S = {params['S']:.2f},\; K = {params['K']:.2f},\; C = {params['C']:.2f},\;"
+        rf"\; P = {params['P']:.2f},\; r = {params['r']:.3f},\; T = {params['T']:.2f}"
+    )
+    st.latex(eq)
+
+    col1, col2 = st.columns(2)
+    with col1:
+        call_choice = st.selectbox("Call", ["Buy", "Sell", "None"])
+        put_choice = st.selectbox("Put", ["Buy", "Sell", "None"])
+    with col2:
+        stock_choice = st.selectbox("Stock", ["Long", "Short", "None"])
+        pvk_choice = st.selectbox("PV(K)", ["Borrow", "Lend", "None"])
+
+    if st.button("Run Simulation"):
+        trade = ts.trade_from_choices(call_choice, put_choice, stock_choice, pvk_choice)
+        cf0, pnls = ts.simulate_trade(params, trade)
+        violated, diff = parity.parity_violation(params)
+        correct_trade = parity.arbitrage_strategy(diff)
+        correct = trade == ts.TRADE_MAP[correct_trade]
+        st.write("Net cash flow at inception:", f"{cf0:.2f}")
+        st.write("P&L Scenarios:")
+        for price, pnl in pnls.items():
+            st.write(f"S={price}: {pnl:.2f}")
+        st.write("Correct" if correct else f"Incorrect, expected: {correct_trade}")
+        st.write("Explanation:")
+        st.latex(r"C - P \stackrel{?}{=} S - K e^{-rT}")
+        st.write(f"Difference: {diff:.2f}")
+        st.write("User trade:", trade)
+        st.write("Required trade:", ts.TRADE_MAP[correct_trade])
 
 elif page == "Delta Hedging":
     st.header("Delta Hedging Simulation")

--- a/trade_simulation.py
+++ b/trade_simulation.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+TRADE_MAP = {
+    "Buy call, sell put, buy stock, borrow PV(K)": {
+        "call": 1,
+        "put": -1,
+        "stock": 1,
+        "pvk": 1,
+    },
+    "Sell call, buy put, short stock, lend PV(K)": {
+        "call": -1,
+        "put": 1,
+        "stock": -1,
+        "pvk": -1,
+    },
+    "No arbitrage": {
+        "call": 0,
+        "put": 0,
+        "stock": 0,
+        "pvk": 0,
+    },
+}
+
+
+def pv_k(K, r, T):
+    """Present value of the strike."""
+    return K * np.exp(-r * T)
+
+
+def trade_from_choices(call_choice, put_choice, stock_choice, pvk_choice):
+    """Convert user selections to trade sign dictionary."""
+    choice_map = {"Buy": 1, "Sell": -1, "None": 0, "Long": 1, "Short": -1, "Borrow": 1, "Lend": -1}
+    return {
+        "call": choice_map.get(call_choice.split()[0], 0),
+        "put": choice_map.get(put_choice.split()[0], 0),
+        "stock": choice_map.get(stock_choice.split()[0], 0),
+        "pvk": choice_map.get(pvk_choice.split()[0], 0),
+    }
+
+
+def simulate_trade(params, trade, S_future=(90, 110, 130)):
+    """Return initial cash flow and P&L for each future stock price."""
+    C = params["C"]
+    P = params["P"]
+    S0 = params["S"]
+    K = params["K"]
+    r = params["r"]
+    T = params["T"]
+    pvk = pv_k(K, r, T)
+
+    cf0 = (
+        -trade["call"] * C
+        - trade["put"] * P
+        - trade["stock"] * S0
+        + trade["pvk"] * pvk
+    )
+
+    results = {}
+    for ST in S_future:
+        call_payoff = max(ST - K, 0)
+        put_payoff = max(K - ST, 0)
+        end = (
+            trade["call"] * call_payoff
+            + trade["put"] * put_payoff
+            + trade["stock"] * ST
+            - trade["pvk"] * K
+        )
+        results[ST] = cf0 + end
+    return cf0, results


### PR DESCRIPTION
## Summary
- create `trade_simulation.py` with utility to compute P&L for arbitrage trades
- add "Arbitrage Simulator" page to app
- show net cash flow and P&L across scenarios

## Testing
- `python -m py_compile app.py trade_simulation.py`

------
https://chatgpt.com/codex/tasks/task_e_686d569f9cbc83339e82f73fff8cfe0e