### PR TITLE
Fix quiz page interface for updated quiz utilities

### DIFF
--- a/pages/quiz.py
+++ b/pages/quiz.py
@@ -4,19 +4,19 @@ from utils import quiz as quiz_utils
 st.header("Quiz")
 
 if "quiz" not in st.session_state:
-    q, opts, ans, idx = quiz_utils.ask_question()
-    st.session_state.quiz = {"q": q, "opts": opts, "ans": ans, "idx": idx}
+    q, idx = quiz_utils.ask_question()
+    st.session_state.quiz = {"q": q, "idx": idx}
 
 qdata = st.session_state.quiz
-st.write(qdata["q"])
-choice = st.radio("Answer", qdata["opts"])
+st.write(qdata["q"]["question"])
+choice = st.radio("Answer", qdata["q"]["options"])
 if st.button("Submit Answer"):
-    correct = qdata["opts"].index(choice) == qdata["ans"]
-    quiz_utils.record_result(correct)
+    correct = qdata["q"]["options"].index(choice) == qdata["q"]["answer"]
+    quiz_utils.record_result(correct, qdata["q"]["topic"])
     st.write("Correct" if correct else "Incorrect")
-    q, opts, ans, idx = quiz_utils.ask_question()
-    st.session_state.quiz = {"q": q, "opts": opts, "ans": ans, "idx": idx}
+    q, idx = quiz_utils.ask_question()
+    st.session_state.quiz = {"q": q, "idx": idx}
 
-score, total = quiz_utils.load_history()
+score, total, *_ = quiz_utils.load_history()
 st.write(f"Score: {score}/{total}")
 


### PR DESCRIPTION
## Summary
- adapt quiz page to new `ask_question` and `record_result` signatures
- display the question text and options from returned question object
- load history with updated return values

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686d5fd5f3588333b86f3fcfffb44ced