### PR TITLE
Fix quiz state and restrict easy input increments

### DIFF
--- a/pages/options_chain.py
+++ b/pages/options_chain.py
@@ -6,10 +6,12 @@ st.header("Options Chain Builder")
 
 difficulty = st.session_state.get("difficulty", "Standard")
 
-spot = st.number_input("Spot Price", value=100.0)
+spot_step = 1.0 if difficulty == "Easy" else 0.1
+width_step = 1.0 if difficulty == "Easy" else 0.5
+spot = st.number_input("Spot Price", value=100.0, step=spot_step)
 r = st.number_input("Risk Free Rate", value=0.01)
 vol = st.number_input("Implied Volatility", value=0.2)
-width = st.number_input("Strike Width", value=5.0)
+width = st.number_input("Strike Width", value=5.0, step=width_step)
 if difficulty == "Easy":
     spot = int(spot)
     width = int(width)

--- a/pages/quiz.py
+++ b/pages/quiz.py
@@ -7,23 +7,19 @@ difficulty = st.session_state.get("difficulty")
 
 if "quiz" not in st.session_state:
     q, idx = quiz_utils.ask_question(difficulty=difficulty)
-    st.session_state.quiz = {"q": q["question"], "opts": q["options"], "ans": q["answer"], "idx": idx, "topic": q.get("topic")}
+    # store the full question dictionary so we can reuse all fields later
+    st.session_state.quiz = {"q": q, "idx": idx}
 
 qdata = st.session_state.quiz
 st.write(qdata["q"]["question"])
 choice = st.radio("Answer", qdata["q"]["options"])
 if st.button("Submit Answer"):
-    correct = qdata["opts"].index(choice) == qdata["ans"]
-    quiz_utils.record_result(correct, qdata.get("topic"))
+    # determine correctness using the stored answer index
+    correct = qdata["q"]["options"].index(choice) == qdata["q"]["answer"]
+    quiz_utils.record_result(correct, qdata["q"].get("topic"))
     st.write("Correct" if correct else "Incorrect")
     q, idx = quiz_utils.ask_question(difficulty=difficulty)
-    st.session_state.quiz = {
-        "q": q["question"],
-        "opts": q["options"],
-        "ans": q["answer"],
-        "idx": idx,
-        "topic": q.get("topic"),
-    }
+    st.session_state.quiz = {"q": q, "idx": idx}
 
 
 score, total, *_ = quiz_utils.load_history()


### PR DESCRIPTION
## Summary
- fix quiz question handling so options and answers work correctly
- restrict easy-mode inputs to whole-number increments in options chain page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d70a3db288333ba95ec38335c9ab0