### PR TITLE
Add interactive arbitrage trainer with scenario generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ An interactive Streamlit app for practicing options trading concepts. The app in
 
 - **Put-Call Parity Practice** with randomly generated parameters
 - **Delta Hedging Simulation** using a simple random walk
+- **Interactive Arbitrage Trainer** with scenario generation and Greek feedback
 - **Quiz Mode** to test knowledge of options theory
 
 ## Getting Started
@@ -14,7 +15,7 @@ An interactive Streamlit app for practicing options trading concepts. The app in
    ```
 2. Run the app:
    ```bash
-   streamlit run app.py
+   streamlit run streamlit_app.py
    ```
 
 ## Requirements
@@ -24,11 +25,11 @@ An interactive Streamlit app for practicing options trading concepts. The app in
 
 ## Project Structure
 
-- `app.py` – Streamlit application entry point
-- `option_pricing.py` – Black-Scholes utilities and Greek calculations
-- `parity.py` – Functions for put-call parity practice
-- `delta_hedging.py` – Helpers for delta hedging simulation
-- `quiz.py` – Quiz logic
-Quiz results are stored in `quiz_history.csv`.
+- `streamlit_app.py` – Main Streamlit application with links to pages
+- `pages/` – Individual app pages (parity, hedging, quiz, trading)
+- `utils/option_pricing.py` – Black-Scholes utilities and Greek calculations
+- `utils/scenario_generator.py` – Random scenario helper
+- `utils/greeks.py` – Net Greeks computation
+- `quiz_history.csv` stores quiz results
 
 This project is intended for use on Windows systems.

--- a/pages/interactive_trading.py
+++ b/pages/interactive_trading.py
@@ -1,0 +1,56 @@
+import streamlit as st
+import pandas as pd
+from utils import trade_simulation as ts
+from utils import scenario_generator
+from utils import greeks
+
+st.header("Interactive Arbitrage Trainer")
+
+if st.button("Generate Scenario") or "scenario" not in st.session_state:
+    st.session_state.scenario = scenario_generator.generate_scenario()
+
+sc = st.session_state.scenario
+
+st.write(
+    f"S={sc['S']:.2f}, K={sc['K']:.2f}, T={sc['T']:.2f}yr, r={sc['r']:.4f}, σ={sc['sigma']:.2f}"
+)
+st.write(
+    f"Call Market={sc['C_mkt']:.2f} (Theo {sc['C_theo']:.2f}),  "
+    f"Put Market={sc['P_mkt']:.2f} (Theo {sc['P_theo']:.2f})"
+)
+
+col1, col2 = st.columns(2)
+with col1:
+    call_action = st.selectbox("Call", ["None", "Buy", "Sell"])
+    put_action = st.selectbox("Put", ["None", "Buy", "Sell"])
+with col2:
+    stock_action = st.selectbox("Stock", ["None", "Long", "Short"])
+    cash_action = st.selectbox("Cash", ["None", "Borrow", "Lend"])
+
+if st.button("Simulate Trade"):
+    trade = ts.trade_from_choices(call_action, put_action, stock_action, cash_action)
+    cf0, pnls = ts.simulate_trade(sc, trade)
+    st.write(f"Initial cash flow: {cf0:.2f}")
+    df = pd.DataFrame({"Price": list(pnls.keys()), "PnL": list(pnls.values())})
+    st.table(df)
+    st.line_chart(df.set_index("Price"))
+
+    correct_trade = ts.TRADE_MAP[sc["arb"]]
+    correct = trade == correct_trade
+    st.write("Trade evaluation:", "Correct" if correct else f"Incorrect ({sc['arb']})")
+
+    pos_greeks = greeks.net_position_greeks(trade, sc['S'], sc['K'], sc['r'], sc['T'], sc['sigma'])
+    sig = {k: v for k, v in pos_greeks.items() if abs(v) > 0.2}
+    user_sel = st.multiselect("Which Greeks matter?", greeks.GREEK_KEYS)
+    if st.button("Check Greeks"):
+        missed = [g for g in sig if g not in user_sel]
+        extra = [g for g in user_sel if g not in sig]
+        if not missed and not extra:
+            st.success("Correct Greeks identified")
+        else:
+            if missed:
+                st.write("Missed:", ", ".join(missed))
+            if extra:
+                st.write("Not significant:", ", ".join(extra))
+        for g, val in pos_greeks.items():
+            st.write(f"{g.capitalize()}: {val:.2f}")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,18 @@
+import streamlit as st
+
+st.set_page_config(page_title="Options Trainer")
+
+st.title("Options Practice Suite")
+st.write("Use the sidebar to select an activity.")
+
+pages = [
+    "parity",
+    "arbitrage_simulator",
+    "delta_hedging",
+    "options_chain",
+    "quiz",
+    "interactive_trading",
+]
+
+for p in pages:
+    st.sidebar.page_link(f"pages/{p}.py", label=p.replace("_", " ").title())

--- a/utils/greeks.py
+++ b/utils/greeks.py
@@ -1,0 +1,51 @@
+import numpy as np
+from .option_pricing import (
+    call_delta,
+    put_delta,
+    gamma,
+    vega,
+    call_theta,
+    put_theta,
+    call_rho,
+    put_rho,
+)
+
+
+GREEK_KEYS = ["delta", "gamma", "vega", "theta", "rho"]
+
+
+def compute_greeks(S, K, r, T, sigma, option_type="call"):
+    """Return dictionary of option Greeks."""
+    if option_type == "call":
+        return {
+            "delta": call_delta(S, K, r, T, sigma),
+            "gamma": gamma(S, K, r, T, sigma),
+            "vega": vega(S, K, r, T, sigma),
+            "theta": call_theta(S, K, r, T, sigma),
+            "rho": call_rho(S, K, r, T, sigma),
+        }
+    else:
+        return {
+            "delta": put_delta(S, K, r, T, sigma),
+            "gamma": gamma(S, K, r, T, sigma),
+            "vega": vega(S, K, r, T, sigma),
+            "theta": put_theta(S, K, r, T, sigma),
+            "rho": put_rho(S, K, r, T, sigma),
+        }
+
+
+def net_position_greeks(trade, S, K, r, T, sigma):
+    """Sum Greeks for a trade dictionary."""
+    call_g = compute_greeks(S, K, r, T, sigma, "call")
+    put_g = compute_greeks(S, K, r, T, sigma, "put")
+    # stock Greeks
+    stock = {"delta": 1.0, "gamma": 0.0, "vega": 0.0, "theta": 0.0, "rho": 0.0}
+    bond = {"delta": 0.0, "gamma": 0.0, "vega": 0.0, "theta": 0.0, "rho": -K * T * np.exp(-r * T) / 100}
+
+    total = {k: 0.0 for k in GREEK_KEYS}
+    for g in GREEK_KEYS:
+        total[g] += trade.get("call", 0) * call_g[g]
+        total[g] += trade.get("put", 0) * put_g[g]
+        total[g] += trade.get("stock", 0) * stock[g]
+        total[g] += trade.get("pvk", 0) * bond[g]
+    return total

--- a/utils/scenario_generator.py
+++ b/utils/scenario_generator.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from .option_pricing import call_price, put_price
+
+
+def generate_scenario():
+    """Return random option scenario with theoretical and market prices."""
+    S = np.round(np.random.uniform(50, 150), 2)
+    K = np.round(np.random.uniform(50, 150) / 0.5) * 0.5
+    T = np.round(np.random.uniform(0.1, 1.0), 2)
+    r = np.round(np.random.uniform(0.01, 0.05), 4)
+    sigma = np.round(np.random.uniform(0.1, 0.7), 2)
+
+    C_theo = call_price(S, K, r, T, sigma)
+    P_theo = put_price(S, K, r, T, sigma)
+
+    # Add small noise to create market prices
+    C_mkt = C_theo + np.random.normal(scale=0.25)
+    P_mkt = P_theo + np.random.normal(scale=0.25)
+
+    pvk = K * np.exp(-r * T)
+    parity = S - pvk
+    diff = C_mkt - P_mkt - parity
+
+    if diff > 0:
+        arb = "Sell call, buy put, short stock, lend PV(K)"
+    elif diff < 0:
+        arb = "Buy call, sell put, buy stock, borrow PV(K)"
+    else:
+        arb = "No arbitrage"
+
+    return {
+        "S": S,
+        "K": K,
+        "T": T,
+        "r": r,
+        "sigma": sigma,
+        "C_theo": C_theo,
+        "P_theo": P_theo,
+        "C_mkt": C_mkt,
+        "P_mkt": P_mkt,
+        "pvk": pvk,
+        "parity_diff": diff,
+        "arb": arb,
+    }


### PR DESCRIPTION
## Summary
- implement random scenario generation helper
- add Greek calculations and net position tools
- build Streamlit page for interactive arbitrage trading and feedback
- provide main `streamlit_app.py` entry linking all pages
- update documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d831316a083338a6ca32e635d03b2