### PR TITLE
Add maker/taker modules and new practice pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,30 @@
 import streamlit as st
+from utils.ui_config import difficulty_selector
 
 st.set_page_config(page_title="Options Trainer")
 
+PAGES = {
+    "Market Taker": "pages/interactive_trader.py",
+    "Market Maker": "pages/interactive_maker.py",
+}
+
+# Hide default Streamlit navigation
+st.markdown(
+    """
+    <style>
+    [data-testid="stSidebarNav"] {display: none;}
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+st.sidebar.title("Practice Modules")
+choice = st.sidebar.radio("Module", list(PAGES.keys()))
+
+difficulty_selector()
+
+if st.sidebar.button("Open Module"):
+    st.switch_page(PAGES[choice])
+
 st.title("Options Practice Suite")
-st.write("Use the sidebar to launch the interactive trader.")
+st.write("Select a module from the sidebar to begin.")

--- a/pages/interactive_maker.py
+++ b/pages/interactive_maker.py
@@ -1,0 +1,37 @@
+import numpy as np
+import streamlit as st
+
+from utils import greeks, option_pricing as op, scenario_generator
+from utils.market_maker import MarketMaker
+from utils.ui_config import difficulty_selector, maker_quote_form
+
+st.set_page_config(page_title="Market Maker")
+
+st.title("Market Maker Practice")
+
+difficulty_selector()
+
+if "scenario" not in st.session_state:
+    st.session_state["scenario"] = scenario_generator.generate_scenario()
+
+sc = st.session_state["scenario"]
+
+call_delta = greeks.call_delta(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
+put_delta = greeks.put_delta(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
+call_theo = op.call_price(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
+put_theo = op.put_price(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
+
+maker = MarketMaker(sc, call_delta, put_delta, call_theo, put_theo)
+
+st.write(sc)
+quote = maker_quote_form()
+if quote:
+    maker.post_quote(**quote)
+    st.success("Quote posted")
+
+if st.button("Simulate Fill") and maker.quote:
+    side = np.random.choice(["buy", "sell"])
+    price = maker.quote["ask"] if side == "buy" else maker.quote["bid"]
+    maker.execute_trade(side, maker.quote["qty"], price)
+    st.success(f"Filled {side} {maker.quote['qty']} @ {price:.2f}")
+    st.write("Inventory:", maker.inventory)

--- a/pages/interactive_trader.py
+++ b/pages/interactive_trader.py
@@ -1,0 +1,29 @@
+import streamlit as st
+
+from utils import greeks, option_pricing as op, scenario_generator
+from utils.market_taker import MarketTaker
+from utils.ui_config import difficulty_selector, taker_trade_form
+
+st.set_page_config(page_title="Market Taker")
+
+st.title("Market Taker Practice")
+
+difficulty_selector()
+
+if "scenario" not in st.session_state:
+    st.session_state["scenario"] = scenario_generator.generate_scenario()
+
+sc = st.session_state["scenario"]
+
+call_delta = greeks.call_delta(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
+put_delta = greeks.put_delta(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
+call_theo = op.call_price(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
+put_theo = op.put_price(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
+
+trader = MarketTaker(sc, call_delta, put_delta, call_theo, put_theo)
+
+st.write(sc)
+trade = taker_trade_form()
+if trade:
+    trader.execute_trade(trade["side"], trade["qty"])
+    st.success(f"Inventory now {trader.inventory}")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,4 @@
+"""Utility modules for optionsMock."""
+
+from .market_maker import MarketMaker
+from .market_taker import MarketTaker

--- a/utils/market_maker.py
+++ b/utils/market_maker.py
@@ -1,0 +1,28 @@
+import streamlit as st
+
+from .live_trader import LiveTrader
+
+
+class MarketMaker(LiveTrader):
+    """Live trader subclass implementing market maker logic."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.inventory = st.session_state.get("maker_inventory", 0)
+        self.quote = None
+
+    def post_quote(self, bid: float, ask: float, qty: int) -> None:
+        """Post a bid/ask quote to the market."""
+        self.quote = {"bid": bid, "ask": ask, "qty": qty}
+        st.session_state.maker_quote = self.quote
+
+    def execute_trade(self, side: str, qty: int, price: float) -> None:
+        """Handle a trade fill against our quote."""
+        if side.lower() == "buy":
+            self.inventory -= qty
+        elif side.lower() == "sell":
+            self.inventory += qty
+        st.session_state.maker_inventory = self.inventory
+        pnl = (price - self.quote[side.lower() == "buy" and "ask" or "bid"]) * qty
+        st.session_state.setdefault("maker_pnl", 0)
+        st.session_state["maker_pnl"] += pnl

--- a/utils/market_taker.py
+++ b/utils/market_taker.py
@@ -1,0 +1,22 @@
+import streamlit as st
+
+from .live_trader import LiveTrader
+
+
+class MarketTaker(LiveTrader):
+    """Simple live trader subclass for taker style workflows."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.inventory = st.session_state.get("taker_inventory", 0)
+
+    def execute_trade(self, side: str, qty: int) -> None:
+        """Execute an immediate trade and update inventory."""
+        if side.lower() == "buy":
+            self.inventory += qty
+        elif side.lower() == "sell":
+            self.inventory -= qty
+        st.session_state.taker_inventory = self.inventory
+
+    def post_quote(self, *args, **kwargs):  # pragma: no cover - placeholder
+        st.info("Market takers do not post quotes.")

--- a/utils/ui_config/__init__.py
+++ b/utils/ui_config/__init__.py
@@ -1,0 +1,1 @@
+from .widgets import difficulty_selector, maker_quote_form, taker_trade_form

--- a/utils/ui_config/widgets.py
+++ b/utils/ui_config/widgets.py
@@ -1,0 +1,31 @@
+import streamlit as st
+
+
+def difficulty_selector() -> str:
+    """Sidebar widget to choose difficulty level."""
+    diff = st.sidebar.selectbox("Difficulty", ["Easy", "Normal", "Hard"], key="difficulty")
+    st.session_state["difficulty"] = diff
+    return diff
+
+
+def taker_trade_form():
+    """Form for market taker trade entry."""
+    with st.form("taker_trade_form"):
+        side = st.selectbox("Side", ["Buy", "Sell"])
+        qty = st.number_input("Quantity", 1, 100, 1)
+        submitted = st.form_submit_button("Execute Trade")
+    if submitted:
+        return {"side": side, "qty": int(qty)}
+    return None
+
+
+def maker_quote_form():
+    """Form for market maker quoting."""
+    with st.form("maker_quote_form"):
+        bid = st.number_input("Bid", value=0.0)
+        ask = st.number_input("Ask", value=0.0)
+        qty = st.number_input("Size", 1, 100, 1)
+        submitted = st.form_submit_button("Post Quote")
+    if submitted:
+        return {"bid": bid, "ask": ask, "qty": int(qty)}
+    return None


### PR DESCRIPTION
## Summary
- implement `MarketTaker` and `MarketMaker` classes with inventory logic
- centralize UI widgets under `utils/ui_config`
- add simple market taker and market maker practice pages
- update `app.py` to navigate to new pages and hide default nav
- expose new utilities from `utils`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686fbc2f1ec08333891c653701b09816