### PR TITLE
Add market maker practice workflow

### DIFF
--- a/pages/interactive_maker.py
+++ b/pages/interactive_maker.py
@@ -3,7 +3,7 @@ import streamlit as st
 
 from utils import greeks, option_pricing as op, scenario_generator
 from utils.market_maker import MarketMaker
-from utils.ui_config import difficulty_selector, maker_quote_form
+from utils.ui_config import difficulty_selector
 
 st.set_page_config(page_title="Market Maker")
 
@@ -21,17 +21,110 @@ put_delta = greeks.put_delta(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
 call_theo = op.call_price(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
 put_theo = op.put_price(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
 
-maker = MarketMaker(sc, call_delta, put_delta, call_theo, put_theo)
+call_edge = call_theo - sc["C_mkt"]
+put_edge = put_theo - sc["P_mkt"]
+combined_delta = call_delta + put_delta
 
+df = np.exp(-sc["r"] * sc["T"])
+
+st.markdown("### Market Scenario")
 st.write(sc)
-quote = maker_quote_form()
-if quote:
-    maker.post_quote(**quote)
-    st.success("Quote posted")
 
-if st.button("Simulate Fill") and maker.quote:
-    side = np.random.choice(["buy", "sell"])
-    price = maker.quote["ask"] if side == "buy" else maker.quote["bid"]
-    maker.execute_trade(side, maker.quote["qty"], price)
-    st.success(f"Filled {side} {maker.quote['qty']} @ {price:.2f}")
-    st.write("Inventory:", maker.inventory)
+st.markdown("### Step 1: Parity & Mispricing")
+with st.form("maker_step1"):
+    call_mid_in = st.number_input("1. Call quote midpoint", format="%.2f")
+    put_mid_in = st.number_input("2. Put quote midpoint", format="%.2f")
+    step1_submit = st.form_submit_button("Check Step 1")
+
+if step1_submit:
+    base_call = sc["C_mkt"] + 0.5 * call_edge
+    base_put = sc["P_mkt"] + 0.5 * put_edge
+    target = sc["S"] - sc["K"] * df
+    diff = base_call - base_put
+    adjust = diff - target
+    correct_call = base_call - adjust / 2
+    correct_put = base_put + adjust / 2
+    ok = abs(call_mid_in - correct_call) < 0.1 and abs(put_mid_in - correct_put) < 0.1
+    if ok:
+        st.success("Midpoints maintain parity and capture edge.")
+        st.session_state.maker_step1 = True
+    else:
+        st.error(f"Expected call {correct_call:.2f}, put {correct_put:.2f}")
+
+if st.session_state.get("maker_step1"):
+    st.markdown("### Step 2: Trade Strategy")
+    with st.form("maker_step2"):
+        lean_side = st.radio(
+            "3. Which side will you lean into first?",
+            ["Buy", "Sell"],
+            horizontal=True,
+        )
+        lean_reason = st.selectbox(
+            "4. Why?",
+            ["Collect premium", "Hedge delta risk", "Manage inventory"],
+        )
+        step2_submit = st.form_submit_button("Check Step 2")
+    if step2_submit:
+        straddle_edge = call_edge + put_edge
+        if abs(straddle_edge) < 0.05:
+            correct_side, correct_reason = "Sell", "Manage inventory"
+        elif straddle_edge > 0:
+            correct_side, correct_reason = "Buy", "Hedge delta risk"
+        else:
+            correct_side, correct_reason = "Sell", "Collect premium"
+        if lean_side == correct_side and lean_reason == correct_reason:
+            st.success("Strategy aligned with edge.")
+            st.session_state.maker_step2 = True
+        else:
+            st.error(f"Expected {correct_side} – {correct_reason}.")
+
+if st.session_state.get("maker_step2"):
+    st.markdown("### Step 3: Greek Risk Analysis")
+    with st.form("maker_step3"):
+        delta_in = st.number_input("5. Net delta from quotes", format="%.3f")
+        hedge_in = st.number_input("6. Shares to hedge", format="%.0f")
+        step3_submit = st.form_submit_button("Check Step 3")
+    if step3_submit:
+        correct_shares = -combined_delta * 100
+        ok_delta = abs(delta_in - combined_delta) < 0.05
+        ok_hedge = abs(hedge_in - correct_shares) <= 5
+        if ok_delta:
+            st.success("Delta correct")
+        else:
+            st.error(f"Expected delta {combined_delta:.3f}")
+        if ok_hedge:
+            st.success(f"Hedge {correct_shares:.0f} shares")
+        else:
+            st.error(f"Expected hedge {correct_shares:.0f}")
+        st.session_state.maker_step3 = True
+
+if st.session_state.get("maker_step3"):
+    st.markdown("### Step 4: Risk Profile")
+    with st.form("maker_step4"):
+        fill_prob = st.slider("7. Expected fill probability (%)", 0, 100, 50)
+        risk_choice = st.radio(
+            "8. Overall risk level?",
+            ["Low", "Medium", "High"],
+            horizontal=True,
+        )
+        notes = st.text_area("9. Explain your reasoning")
+        step4_submit = st.form_submit_button("Submit Step 4")
+    if step4_submit:
+        exposure = abs(combined_delta) * 100 * fill_prob / 100
+        if exposure < 10:
+            correct_risk = "Low"
+        elif exposure < 30:
+            correct_risk = "Medium"
+        else:
+            correct_risk = "High"
+        if risk_choice == correct_risk:
+            st.success("Risk assessment reasonable")
+        else:
+            st.error(f"Expected risk level {correct_risk}")
+        st.session_state.maker_step4 = True
+
+if st.session_state.get("maker_step4"):
+    st.markdown("## Live Quoting Simulation")
+    maker = MarketMaker(sc, call_delta, put_delta, call_theo, put_theo)
+    maker.render()
+

--- a/utils/market_maker.py
+++ b/utils/market_maker.py
@@ -1,6 +1,8 @@
+import numpy as np
 import streamlit as st
 
 from .live_trader import LiveTrader
+from .ui_config import maker_quote_form
 
 
 class MarketMaker(LiveTrader):
@@ -10,6 +12,7 @@ class MarketMaker(LiveTrader):
         super().__init__(*args, **kwargs)
         self.inventory = st.session_state.get("maker_inventory", 0)
         self.quote = None
+        self.pnl_history = st.session_state.get("maker_pnl_history", [])
 
     def post_quote(self, bid: float, ask: float, qty: int) -> None:
         """Post a bid/ask quote to the market."""
@@ -26,3 +29,30 @@ class MarketMaker(LiveTrader):
         pnl = (price - self.quote[side.lower() == "buy" and "ask" or "bid"]) * qty
         st.session_state.setdefault("maker_pnl", 0)
         st.session_state["maker_pnl"] += pnl
+
+    # --- Simple Quoting Simulation Interface ---
+    def render(self) -> None:
+        """Render quote posting and simulated fill workflow."""
+        st.subheader("Live Quoting")
+
+        quote = maker_quote_form()
+        if quote:
+            self.post_quote(**quote)
+            st.success("Quote posted")
+
+        if self.quote and st.button("Simulate Fill"):
+            side = np.random.choice(["buy", "sell"])
+            price = self.quote["ask"] if side == "buy" else self.quote["bid"]
+            self.execute_trade(side, self.quote["qty"], price)
+            st.success(f"Filled {side} {self.quote['qty']} @ {price:.2f}")
+            st.write("Inventory:", self.inventory)
+
+        current_pnl = st.session_state.get("maker_pnl", 0)
+        if self.pnl_history and self.pnl_history[-1] == current_pnl:
+            pass
+        else:
+            self.pnl_history.append(current_pnl)
+            st.session_state.maker_pnl_history = self.pnl_history
+
+        if self.pnl_history:
+            st.line_chart(self.pnl_history)


### PR DESCRIPTION
## Summary
- implement stepwise `interactive_maker.py` with four training stages
- extend `MarketMaker` with `render` method for quoting simulation and P&L chart

## Testing
- `python -m py_compile pages/interactive_maker.py utils/market_maker.py`

------
https://chatgpt.com/codex/tasks/task_e_686fc51c81cc833385ce1e13abdc3963