### PR TITLE
Add taker training workflow and scenario UI fixes

### DIFF
--- a/pages/interactive_maker.py
+++ b/pages/interactive_maker.py
@@ -1,9 +1,10 @@
 import numpy as np
+import pandas as pd
 import streamlit as st
 
 from utils import greeks, option_pricing as op, scenario_generator
 from utils.market_maker import MarketMaker
-from utils.ui_config import difficulty_selector, maker_quote_form
+from utils.ui_config import difficulty_selector
 
 st.set_page_config(page_title="Market Maker")
 
@@ -11,27 +12,148 @@ st.title("Market Maker Practice")
 
 difficulty_selector()
 
-if "scenario" not in st.session_state:
-    st.session_state["scenario"] = scenario_generator.generate_scenario()
+if (
+    st.button("Generate New Scenario", key="maker_new")
+    or "scenario" not in st.session_state
+):
+    st.session_state.scenario = scenario_generator.generate_scenario()
+    for key in ["maker_step1", "maker_step2", "maker_step3", "maker_step4"]:
+        st.session_state.pop(key, None)
 
-sc = st.session_state["scenario"]
+sc = st.session_state.scenario
 
 call_delta = greeks.call_delta(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
 put_delta = greeks.put_delta(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
 call_theo = op.call_price(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
 put_theo = op.put_price(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
 
-maker = MarketMaker(sc, call_delta, put_delta, call_theo, put_theo)
+call_edge = call_theo - sc["C_mkt"]
+put_edge = put_theo - sc["P_mkt"]
+combined_delta = call_delta + put_delta
 
-st.write(sc)
-quote = maker_quote_form()
-if quote:
-    maker.post_quote(**quote)
-    st.success("Quote posted")
+discount_factor = np.exp(-sc["r"] * sc["T"])
 
-if st.button("Simulate Fill") and maker.quote:
-    side = np.random.choice(["buy", "sell"])
-    price = maker.quote["ask"] if side == "buy" else maker.quote["bid"]
-    maker.execute_trade(side, maker.quote["qty"], price)
-    st.success(f"Filled {side} {maker.quote['qty']} @ {price:.2f}")
-    st.write("Inventory:", maker.inventory)
+st.subheader("Market Scenario")
+
+env_data = {
+    "Spot (S)": f"${sc['S']:.2f}",
+    "Strike (K)": f"${sc['K']:.2f}",
+    "Rate (r)": f"{sc['r']:.2%}",
+    "Time to Expiration (T)": f"{sc['T']:.2f} yrs",
+    "Volatility (σ)": f"{sc['sigma']:.2%}",
+    "e^{-rT}": f"{discount_factor:.4f}",
+}
+
+st.markdown("### Market Environment")
+for label, val in env_data.items():
+    if label == "e^{-rT}":
+        st.latex(rf"{label} = {val}")
+    else:
+        st.markdown(f"**{label}:** {val}")
+
+option_data = {
+    "Metric": ["Market Price", "Theoretical Price", "Delta"],
+    "Call": [f"${sc['C_mkt']:.2f}", f"${call_theo:.2f}", f"{call_delta:.2f}"],
+    "Put": [f"${sc['P_mkt']:.2f}", f"${put_theo:.2f}", "—"],
+}
+option_df = pd.DataFrame(option_data)
+st.table(option_df)
+
+st.markdown("### Step 1: Parity & Mispricing")
+with st.form("maker_step1"):
+    call_mid_in = st.number_input("1. Call quote midpoint", format="%.2f")
+    put_mid_in = st.number_input("2. Put quote midpoint", format="%.2f")
+    step1_submit = st.form_submit_button("Check Step 1")
+
+if step1_submit:
+    base_call = sc["C_mkt"] + 0.5 * call_edge
+    base_put = sc["P_mkt"] + 0.5 * put_edge
+    target = sc["S"] - sc["K"] * discount_factor
+    diff = base_call - base_put
+    adjust = diff - target
+    correct_call = base_call - adjust / 2
+    correct_put = base_put + adjust / 2
+    ok = abs(call_mid_in - correct_call) < 0.1 and abs(put_mid_in - correct_put) < 0.1
+    if ok:
+        st.success("Midpoints maintain parity and capture edge.")
+        st.session_state.maker_step1 = True
+    else:
+        st.error(f"Expected call {correct_call:.2f}, put {correct_put:.2f}")
+
+if st.session_state.get("maker_step1"):
+    st.markdown("### Step 2: Trade Strategy")
+    with st.form("maker_step2"):
+        lean_side = st.radio(
+            "3. Which side will you lean into first?",
+            ["Buy", "Sell"],
+            horizontal=True,
+        )
+        lean_reason = st.selectbox(
+            "4. Why?",
+            ["Collect premium", "Hedge delta risk", "Manage inventory"],
+        )
+        step2_submit = st.form_submit_button("Check Step 2")
+    if step2_submit:
+        straddle_edge = call_edge + put_edge
+        if abs(straddle_edge) < 0.05:
+            correct_side, correct_reason = "Sell", "Manage inventory"
+        elif straddle_edge > 0:
+            correct_side, correct_reason = "Buy", "Hedge delta risk"
+        else:
+            correct_side, correct_reason = "Sell", "Collect premium"
+        if lean_side == correct_side and lean_reason == correct_reason:
+            st.success("Strategy aligned with edge.")
+            st.session_state.maker_step2 = True
+        else:
+            st.error(f"Expected {correct_side} – {correct_reason}.")
+
+if st.session_state.get("maker_step2"):
+    st.markdown("### Step 3: Greek Risk Analysis")
+    with st.form("maker_step3"):
+        delta_in = st.number_input("5. Net delta from quotes", format="%.3f")
+        hedge_in = st.number_input("6. Shares to hedge", format="%.0f")
+        step3_submit = st.form_submit_button("Check Step 3")
+    if step3_submit:
+        correct_shares = -combined_delta * 100
+        ok_delta = abs(delta_in - combined_delta) < 0.05
+        ok_hedge = abs(hedge_in - correct_shares) <= 5
+        if ok_delta:
+            st.success("Delta correct")
+        else:
+            st.error(f"Expected delta {combined_delta:.3f}")
+        if ok_hedge:
+            st.success(f"Hedge {correct_shares:.0f} shares")
+        else:
+            st.error(f"Expected hedge {correct_shares:.0f}")
+        st.session_state.maker_step3 = True
+
+if st.session_state.get("maker_step3"):
+    st.markdown("### Step 4: Risk Profile")
+    with st.form("maker_step4"):
+        fill_prob = st.slider("7. Expected fill probability (%)", 0, 100, 50)
+        risk_choice = st.radio(
+            "8. Overall risk level?",
+            ["Low", "Medium", "High"],
+            horizontal=True,
+        )
+        notes = st.text_area("9. Explain your reasoning")
+        step4_submit = st.form_submit_button("Submit Step 4")
+    if step4_submit:
+        exposure = abs(combined_delta) * 100 * fill_prob / 100
+        if exposure < 10:
+            correct_risk = "Low"
+        elif exposure < 30:
+            correct_risk = "Medium"
+        else:
+            correct_risk = "High"
+        if risk_choice == correct_risk:
+            st.success("Risk assessment reasonable")
+        else:
+            st.error(f"Expected risk level {correct_risk}")
+        st.session_state.maker_step4 = True
+
+if st.session_state.get("maker_step4"):
+    st.markdown("## Live Quoting Simulation")
+    maker = MarketMaker(sc, call_delta, put_delta, call_theo, put_theo)
+    maker.render()
+

--- a/pages/interactive_trader.py
+++ b/pages/interactive_trader.py
@@ -1,8 +1,10 @@
+import numpy as np
+import pandas as pd
 import streamlit as st
 
 from utils import greeks, option_pricing as op, scenario_generator
 from utils.market_taker import MarketTaker
-from utils.ui_config import difficulty_selector, taker_trade_form
+from utils.ui_config import difficulty_selector
 
 st.set_page_config(page_title="Market Taker")
 
@@ -10,20 +12,188 @@ st.title("Market Taker Practice")
 
 difficulty_selector()
 
-if "scenario" not in st.session_state:
-    st.session_state["scenario"] = scenario_generator.generate_scenario()
+if st.button("Generate New Scenario", key="taker_new") or "scenario" not in st.session_state:
+    st.session_state.scenario = scenario_generator.generate_scenario()
+    for key in ["taker_step1", "taker_step2", "taker_step3", "taker_step4"]:
+        st.session_state.pop(key, None)
 
-sc = st.session_state["scenario"]
+sc = st.session_state.scenario
 
 call_delta = greeks.call_delta(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
 put_delta = greeks.put_delta(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
 call_theo = op.call_price(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
 put_theo = op.put_price(sc["S"], sc["K"], sc["r"], sc["T"], sc["sigma"])
 
+call_edge = call_theo - sc["C_mkt"]
+put_edge = put_theo - sc["P_mkt"]
+discount_factor = np.exp(-sc["r"] * sc["T"])
+parity_gap = sc["C_mkt"] - sc["P_mkt"] - (sc["S"] - sc["K"] * discount_factor)
+
 trader = MarketTaker(sc, call_delta, put_delta, call_theo, put_theo)
 
-st.write(sc)
-trade = taker_trade_form()
-if trade:
-    trader.execute_trade(trade["side"], trade["qty"])
-    st.success(f"Inventory now {trader.inventory}")
+st.subheader("Market Scenario")
+
+env_data = {
+    "Spot (S)": f"${sc['S']:.2f}",
+    "Strike (K)": f"${sc['K']:.2f}",
+    "Rate (r)": f"{sc['r']:.2%}",
+    "Time to Expiration (T)": f"{sc['T']:.2f} yrs",
+    "Volatility (σ)": f"{sc['sigma']:.2%}",
+    "e^{-rT}": f"{discount_factor:.4f}",
+}
+
+st.markdown("### Market Environment")
+for label, val in env_data.items():
+    if label == "e^{-rT}":
+        st.latex(rf"{label} = {val}")
+    else:
+        st.markdown(f"**{label}:** {val}")
+
+option_data = {
+    "Metric": ["Market Price", "Theoretical Price", "Delta"],
+    "Call": [f"${sc['C_mkt']:.2f}", f"${call_theo:.2f}", f"{call_delta:.2f}"],
+    "Put": [f"${sc['P_mkt']:.2f}", f"${put_theo:.2f}", "—"],
+}
+option_df = pd.DataFrame(option_data)
+st.table(option_df)
+
+st.markdown("### Step 1: Parity & Mispricing")
+with st.form("taker_step1"):
+    parity_in = st.number_input("1. Parity gap", format="%.3f")
+    col1, col2 = st.columns(2)
+    with col1:
+        call_mis = st.radio(
+            "2a. Call value", ["Cheap", "Fair", "Expensive"], index=1, horizontal=True
+        )
+    with col2:
+        put_mis = st.radio(
+            "2b. Put value", ["Cheap", "Fair", "Expensive"], index=1, horizontal=True
+        )
+    step1_submit = st.form_submit_button("Check Step 1")
+
+if step1_submit:
+    def assess(edge):
+        if edge > 0.05:
+            return "Cheap"
+        elif edge < -0.05:
+            return "Expensive"
+        else:
+            return "Fair"
+
+    correct_call = assess(call_edge)
+    correct_put = assess(put_edge)
+    ok_parity = abs(parity_in - parity_gap) < 0.01
+    ok_call = call_mis == correct_call
+    ok_put = put_mis == correct_put
+    if ok_parity and ok_call and ok_put:
+        st.success("Step 1 correct")
+        st.session_state.taker_step1 = True
+    else:
+        st.error(
+            f"Expected parity {parity_gap:.3f}, call {correct_call}, put {correct_put}"
+        )
+
+if st.session_state.get("taker_step1"):
+    st.markdown("### Step 2: Trade Strategy")
+    with st.form("taker_step2"):
+        call_action = st.radio(
+            "3a. Call action", ["Buy call", "Sell call", "No call trade"], horizontal=True
+        )
+        put_action = st.radio(
+            "3b. Put action", ["Buy put", "Sell put", "No put trade"], horizontal=True
+        )
+        exp_profit = st.number_input("4. Expected profit per contract ($)", format="%.2f")
+        step2_submit = st.form_submit_button("Check Step 2")
+
+    if step2_submit:
+        def get_correct_actions():
+            if abs(parity_gap) > 0.1:
+                if call_edge + put_edge > 0:
+                    return ("Buy call", "Buy put")
+                else:
+                    return ("Sell call", "Sell put")
+            c_act = "Buy call" if call_edge > 0.05 else "Sell call" if call_edge < -0.05 else "No call trade"
+            p_act = "Buy put" if put_edge > 0.05 else "Sell put" if put_edge < -0.05 else "No put trade"
+            return (c_act, p_act)
+
+        correct_call_act, correct_put_act = get_correct_actions()
+
+        expected_edge = (
+            abs(call_edge + put_edge)
+            if correct_call_act.startswith("Buy") and correct_put_act.startswith("Buy")
+            or correct_call_act.startswith("Sell") and correct_put_act.startswith("Sell")
+            else abs(call_edge) if "call" in correct_call_act else abs(put_edge)
+        )
+
+        ok_call = call_action == correct_call_act
+        ok_put = put_action == correct_put_act
+        ok_profit = abs(exp_profit - expected_edge) < 0.1
+
+        if ok_call and ok_put and ok_profit:
+            st.success("Strategy sound")
+            st.session_state.taker_step2 = True
+            st.session_state.taker_call_action = call_action
+            st.session_state.taker_put_action = put_action
+        else:
+            st.error(
+                f"Expected {correct_call_act}/{correct_put_act} profit ${expected_edge:.2f}"
+            )
+
+if st.session_state.get("taker_step2"):
+    st.markdown("### Step 3: Greek Risk Analysis")
+    with st.form("taker_step3"):
+        delta_in = st.number_input("5. Net delta", format="%.3f")
+        hedge_shares = st.number_input("6. Shares to hedge", format="%.0f")
+        step3_submit = st.form_submit_button("Check Step 3")
+
+    if step3_submit:
+        def action_delta(action, delta):
+            if action.startswith("Buy"):
+                return delta
+            elif action.startswith("Sell"):
+                return -delta
+            return 0
+
+        call_action_val = st.session_state.get("taker_call_action")
+        put_action_val = st.session_state.get("taker_put_action")
+        correct_delta = action_delta(call_action_val, call_delta) + action_delta(put_action_val, put_delta)
+        correct_hedge = -correct_delta * 100
+
+        ok_delta = abs(delta_in - correct_delta) < 0.05
+        ok_hedge = abs(hedge_shares - correct_hedge) <= 5
+        if ok_delta:
+            st.success("Delta correct")
+        else:
+            st.error(f"Expected delta {correct_delta:.3f}")
+        if ok_hedge:
+            st.success(f"Hedge {correct_hedge:.0f} shares")
+        else:
+            st.error(f"Expected hedge {correct_hedge:.0f}")
+        st.session_state.taker_step3 = True
+        st.session_state.taker_delta = delta_in
+
+if st.session_state.get("taker_step3"):
+    st.markdown("### Step 4: Risk Profile")
+    with st.form("taker_step4"):
+        risk_lvl = st.radio(
+            "7. Overall risk level?", ["Low", "Medium", "High"], horizontal=True
+        )
+        notes = st.text_area("8. Explain your reasoning")
+        step4_submit = st.form_submit_button("Submit Step 4")
+    if step4_submit:
+        exposure = abs(st.session_state.get("taker_delta", 0)) * 100
+        if exposure < 10:
+            correct = "Low"
+        elif exposure < 30:
+            correct = "Medium"
+        else:
+            correct = "High"
+        if risk_lvl == correct:
+            st.success("Assessment recorded")
+        else:
+            st.error(f"Expected risk level {correct}")
+        st.session_state.taker_step4 = True
+
+if st.session_state.get("taker_step4"):
+    st.markdown("## Live Trading Simulation")
+    trader.render()

--- a/utils/market_maker.py
+++ b/utils/market_maker.py
@@ -1,6 +1,8 @@
+import numpy as np
 import streamlit as st
 
 from .live_trader import LiveTrader
+from .ui_config import maker_quote_form
 
 
 class MarketMaker(LiveTrader):
@@ -10,6 +12,7 @@ class MarketMaker(LiveTrader):
         super().__init__(*args, **kwargs)
         self.inventory = st.session_state.get("maker_inventory", 0)
         self.quote = None
+        self.pnl_history = st.session_state.get("maker_pnl_history", [])
 
     def post_quote(self, bid: float, ask: float, qty: int) -> None:
         """Post a bid/ask quote to the market."""
@@ -26,3 +29,30 @@ class MarketMaker(LiveTrader):
         pnl = (price - self.quote[side.lower() == "buy" and "ask" or "bid"]) * qty
         st.session_state.setdefault("maker_pnl", 0)
         st.session_state["maker_pnl"] += pnl
+
+    # --- Simple Quoting Simulation Interface ---
+    def render(self) -> None:
+        """Render quote posting and simulated fill workflow."""
+        st.subheader("Live Quoting")
+
+        quote = maker_quote_form()
+        if quote:
+            self.post_quote(**quote)
+            st.success("Quote posted")
+
+        if self.quote and st.button("Simulate Fill"):
+            side = np.random.choice(["buy", "sell"])
+            price = self.quote["ask"] if side == "buy" else self.quote["bid"]
+            self.execute_trade(side, self.quote["qty"], price)
+            st.success(f"Filled {side} {self.quote['qty']} @ {price:.2f}")
+            st.write("Inventory:", self.inventory)
+
+        current_pnl = st.session_state.get("maker_pnl", 0)
+        if self.pnl_history and self.pnl_history[-1] == current_pnl:
+            pass
+        else:
+            self.pnl_history.append(current_pnl)
+            st.session_state.maker_pnl_history = self.pnl_history
+
+        if self.pnl_history:
+            st.line_chart(self.pnl_history)


### PR DESCRIPTION
## Summary
- regenerate scenario for maker practice and format like trading page
- introduce multi-step market taker training in `interactive_trader`
- display scenario details in both pages using consistent tables

## Testing
- `python -m py_compile pages/interactive_maker.py utils/market_maker.py pages/interactive_trader.py utils/market_taker.py`


------
https://chatgpt.com/codex/tasks/task_e_686fc51c81cc833385ce1e13abdc3963